### PR TITLE
Should allow for specific CompletableFuture implementations

### DIFF
--- a/src/main/java/graphql/execution/async/CompletableFutureFactory.java
+++ b/src/main/java/graphql/execution/async/CompletableFutureFactory.java
@@ -1,0 +1,7 @@
+package graphql.execution.async;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface CompletableFutureFactory {
+  <T> CompletableFuture<T> future();
+}

--- a/src/main/java/graphql/execution/async/DefaultCompletableFutureFactory.java
+++ b/src/main/java/graphql/execution/async/DefaultCompletableFutureFactory.java
@@ -1,0 +1,15 @@
+package graphql.execution.async;
+
+import java.util.concurrent.CompletableFuture;
+
+public class DefaultCompletableFutureFactory implements CompletableFutureFactory {
+
+  public static CompletableFutureFactory defaultFactory() {
+    return new DefaultCompletableFutureFactory();
+  }
+
+  @Override
+  public <T> CompletableFuture<T> future() {
+    return new CompletableFuture<>();
+  }
+}


### PR DESCRIPTION
@dminkovsky, I've converted some code to make use of your async implementation and I'm currently playing with it.

My sample project uses Vert.x and I want to make use of Vert.x event loop threads or worker threads. It just happens that the amazing @cescoffier wrote a [CompletableFuture implementation for Vertx](https://github.com/cescoffier/vertx-completable-future).

Based on this I would think that one thing that its missing here is to have a way to pass a CompletableFuture factory to AsyncExecutionStrategy in order to allow other frameworks/toolkits to make best use of their threading mechanism.

What do you think?
